### PR TITLE
Django needs MySQL client 1.4.3

### DIFF
--- a/horizon/templates/bin/_manage.py.tpl
+++ b/horizon/templates/bin/_manage.py.tpl
@@ -23,7 +23,7 @@ import os
 import sys
 
 import pymysql
-pymysql.version_info = (1, 4, 0, "final", 0)
+pymysql.version_info = (1, 4, 3, "final", 0)
 pymysql.install_as_MySQLdb()
 
 from django.core.management import execute_from_command_line


### PR DESCRIPTION
Otherwise Dashboard greets you with (very weird btw):

```
django.core.exceptions.ImproperlyConfigured: mysqlclient 1.4.3 or newer is required; you have 1.4.6.
```